### PR TITLE
fix: make cluster infos required

### DIFF
--- a/charts/kyverno-aws-adapter/templates/resource.yaml
+++ b/charts/kyverno-aws-adapter/templates/resource.yaml
@@ -9,5 +9,5 @@ metadata:
   name: {{ .Values.eksCluster.name }}-config
   namespace: {{ .Release.Namespace }}
 spec:
-  name: {{ .Values.eksCluster.name }}
-  region: {{ .Values.eksCluster.region }}
+  name: {{ required "EKS cluster name is required" .Values.eksCluster.name }}
+  region: {{ required "EKS cluster region is required" .Values.eksCluster.region }}


### PR DESCRIPTION
This PR makes cluster infos required when deploying the chart.