### PR TITLE
Update eksConfig to eksCluster

### DIFF
--- a/config/samples/policies/check-cluster-tags.yaml
+++ b/config/samples/policies/check-cluster-tags.yaml
@@ -23,6 +23,6 @@ spec:
         message: "The `department` tag on the cluster is required. The field status.eksConfig.tags.department must exist with some value."
         pattern:
           status:
-            eksConfig:
+            eksCluster:
               tags:
                 department: "?*"


### PR DESCRIPTION
The right key in aws adapter's status field is eksCluster. Changing the key to eksCluster in the policy