### PR TITLE
fix: handle graceful deletion of awsadapterconfig

### DIFF
--- a/config/samples/security_v1alpha1_awsadapterconfig.yaml
+++ b/config/samples/security_v1alpha1_awsadapterconfig.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: kyverno-aws-adapter
     app.kubernetes.io/created-by: kyverno-aws-adapter
   name: test-config
-  namespace: abcd
+  namespace: default
 spec:
   name: test
   region: us-west-1

--- a/controllers/awsadapterconfig_controller.go
+++ b/controllers/awsadapterconfig_controller.go
@@ -59,11 +59,14 @@ func (r *AWSAdapterConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	objOld := &securityv1alpha1.AWSAdapterConfig{}
 	err := r.Get(ctx, req.NamespacedName, objOld)
 	if err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			l.Info("WARNING: Resource deleted or does not exist")
+		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	if !objOld.DeletionTimestamp.IsZero() {
-		l.Info("Deleting AWSAdapterConfig")
+		l.Info("Deleting resource")
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/awsadapterconfig_controller.go
+++ b/controllers/awsadapterconfig_controller.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -63,26 +62,8 @@ func (r *AWSAdapterConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	awsacfgFinalizer := "security.nirmata.io/finalizer"
-	if objOld.DeletionTimestamp.IsZero() {
-		if !controllerutil.ContainsFinalizer(objOld, awsacfgFinalizer) {
-			controllerutil.AddFinalizer(objOld, awsacfgFinalizer)
-			l.Info("Adding Finalizer", "finalizer", awsacfgFinalizer)
-			if err := r.Update(ctx, objOld); err != nil {
-				l.Error(err, "error occurred while adding finalizer")
-				return r.updateLastPollStatusFailure(ctx, objOld, "error occurred while adding finalizer", err, &l, time.Now())
-			}
-			return ctrl.Result{}, nil
-		}
-	} else {
-		if controllerutil.ContainsFinalizer(objOld, awsacfgFinalizer) {
-			controllerutil.RemoveFinalizer(objOld, awsacfgFinalizer)
-			l.Info("Removing Finalizer", "finalizer", awsacfgFinalizer)
-			if err := r.Update(ctx, objOld); err != nil {
-				l.Error(err, "error occurred while removing finalizer")
-				return r.updateLastPollStatusFailure(ctx, objOld, "error occurred while removing finalizer", err, &l, time.Now())
-			}
-		}
+	if !objOld.DeletionTimestamp.IsZero() {
+		l.Info("Deleting AWSAdapterConfig")
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/awsadapterconfig_controller.go
+++ b/controllers/awsadapterconfig_controller.go
@@ -60,13 +60,13 @@ func (r *AWSAdapterConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	err := r.Get(ctx, req.NamespacedName, objOld)
 	if err != nil {
 		if client.IgnoreNotFound(err) == nil {
-			l.Info("WARNING: Resource deleted or does not exist")
+			l.Info("Warning: Resource deleted or does not exist")
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	if !objOld.DeletionTimestamp.IsZero() {
-		l.Info("Deleting resource")
+		l.Info("Warning: Deleting resource. Hope this is done intentionally.")
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
Signed-off-by: Abhinav Sinha <abhinav@nirmata.com>

Handle the graceful deletion of `AWSAdapterConfig` custom resources by performing checks on the deletion timestamp and creating relevant logs.

cc - @anusha94