### PR TITLE
fix: prevent overwriting of error from GetCallerIdentity when it's not nil

### DIFF
--- a/controllers/awsadapterconfig_controller.go
+++ b/controllers/awsadapterconfig_controller.go
@@ -108,11 +108,7 @@ func (r *AWSAdapterConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	callerIdentity, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 	if err != nil || callerIdentity == nil || callerIdentity.Account == nil {
-		if err != nil {
-			l.Error(err, "GetCallerIdentity returned error")
-		}
-		
-		if callerIdentity == nil || callerIdentity.Account == nil {
+		if err == nil {
 			err = fmt.Errorf("callerIdentity nil")
 		}
 

--- a/controllers/awsadapterconfig_controller.go
+++ b/controllers/awsadapterconfig_controller.go
@@ -108,7 +108,7 @@ func (r *AWSAdapterConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	callerIdentity, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 	if err != nil || callerIdentity == nil || callerIdentity.Account == nil {
-		if callerIdentity == nil || callerIdentity.Account == nil {
+		if err == nil {
 			err = fmt.Errorf("callerIdentity nil")
 		}
 

--- a/controllers/awsadapterconfig_controller.go
+++ b/controllers/awsadapterconfig_controller.go
@@ -108,7 +108,11 @@ func (r *AWSAdapterConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	callerIdentity, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 	if err != nil || callerIdentity == nil || callerIdentity.Account == nil {
-		if err == nil {
+		if err != nil {
+			l.Error(err, "GetCallerIdentity returned error")
+		}
+		
+		if callerIdentity == nil || callerIdentity.Account == nil {
 			err = fmt.Errorf("callerIdentity nil")
 		}
 


### PR DESCRIPTION
In Reconcile [here](https://github.com/nirmata/kyverno-aws-adapter/blob/8357d4135745656f326584eb662623ede15519bc/controllers/awsadapterconfig_controller.go#L111), error is overwritten when the error was not nil, [[doc reference](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/STS.html#getCallerIdentity-property:~:text=Object\)%20%E2%80%94-,the%20de%2Dserialized%20data%20returned%20from%20the%20request.%20Set%20to%20null%20if%20a%20request%20error%20occurs.%20The%20data%20object%20has%20the%20following%20properties%3A,-UserId%20%E2%80%94%20\(String)].