### PR TITLE
chore: move AMIs from instances to nodegroups

### DIFF
--- a/api/v1alpha1/awsadapterconfig_types.go
+++ b/api/v1alpha1/awsadapterconfig_types.go
@@ -82,26 +82,26 @@ type EKSCompute struct {
 
 // EKSNodeGroup contains info of the EKS cluster's node group
 type EKSNodeGroup struct {
-	Name                string                          `json:"name,omitempty"`
-	NodegroupArn        *string                         `json:"nodeGroupArn,omitempty"`
-	NodeRole            *string                         `json:"nodeRole,omitempty"`
-	CreatedAt           string                          `json:"createdAt,omitempty"`
-	Status              string                          `json:"status,omitempty"`
-	DiskSize            *int32                          `json:"diskSize,omitempty"`
-	AMIType             string                          `json:"amiType,omitempty"`
-	CapacityType        string                          `json:"capacityType,omitempty"`
-	AMIReleaseVersion   *string                         `json:"amiReleaseVersion,omitempty"`
-	Subnets             []string                        `json:"subnets,omitempty"`
-	AmazonMachineImages []AmazonMachineImage            `json:"amazonMachineImages,omitempty"`
-	UpdateConfig        *EKSNodeGroupUpdateConfig       `json:"updateConfig,omitempty"`
-	ScalingConfig       *EKSNodeGroupScalingConfig      `json:"scalingConfig,omitempty"`
-	LaunchTemplate      *EC2LaunchTemplate              `json:"launchTemplate,omitempty"`
-	RemoteAccessConfig  *EKSNodeGroupRemoteAccessConfig `json:"remoteAccessConfig,omitempty"`
-	Resources           *EKSNodeGroupResources          `json:"resources,omitempty"`
-	HealthIssues        []*EKSNodeGroupHealthIssue      `json:"healthIssues,omitempty"`
-	Taints              []*EKSNodeGroupTaint            `json:"taints,omitempty"`
-	Labels              map[string]string               `json:"labels,omitempty"`
-	Tags                map[string]string               `json:"tags,omitempty"`
+	Name               string                          `json:"name,omitempty"`
+	NodegroupArn       *string                         `json:"nodeGroupArn,omitempty"`
+	NodeRole           *string                         `json:"nodeRole,omitempty"`
+	CreatedAt          string                          `json:"createdAt,omitempty"`
+	Status             string                          `json:"status,omitempty"`
+	DiskSize           *int32                          `json:"diskSize,omitempty"`
+	AMIType            string                          `json:"amiType,omitempty"`
+	CapacityType       string                          `json:"capacityType,omitempty"`
+	AMIReleaseVersion  *string                         `json:"amiReleaseVersion,omitempty"`
+	Subnets            []string                        `json:"subnets,omitempty"`
+	AmazonMachineImage AmazonMachineImage              `json:"amazonMachineImage,omitempty"`
+	UpdateConfig       *EKSNodeGroupUpdateConfig       `json:"updateConfig,omitempty"`
+	ScalingConfig      *EKSNodeGroupScalingConfig      `json:"scalingConfig,omitempty"`
+	LaunchTemplate     *EC2LaunchTemplate              `json:"launchTemplate,omitempty"`
+	RemoteAccessConfig *EKSNodeGroupRemoteAccessConfig `json:"remoteAccessConfig,omitempty"`
+	Resources          *EKSNodeGroupResources          `json:"resources,omitempty"`
+	HealthIssues       []*EKSNodeGroupHealthIssue      `json:"healthIssues,omitempty"`
+	Taints             []*EKSNodeGroupTaint            `json:"taints,omitempty"`
+	Labels             map[string]string               `json:"labels,omitempty"`
+	Tags               map[string]string               `json:"tags,omitempty"`
 }
 
 // EKSNodeGroupUpdateConfig contains number/percentage of node groups that can be updated in parallel

--- a/api/v1alpha1/awsadapterconfig_types.go
+++ b/api/v1alpha1/awsadapterconfig_types.go
@@ -82,26 +82,26 @@ type EKSCompute struct {
 
 // EKSNodeGroup contains info of the EKS cluster's node group
 type EKSNodeGroup struct {
-	Name               string                          `json:"name,omitempty"`
-	NodegroupArn       *string                         `json:"nodeGroupArn,omitempty"`
-	NodeRole           *string                         `json:"nodeRole,omitempty"`
-	CreatedAt          string                          `json:"createdAt,omitempty"`
-	Status             string                          `json:"status,omitempty"`
-	DiskSize           *int32                          `json:"diskSize,omitempty"`
-	AMIType            string                          `json:"amiType,omitempty"`
-	CapacityType       string                          `json:"capacityType,omitempty"`
-	AMIReleaseVersion  *string                         `json:"amiReleaseVersion,omitempty"`
-	Subnets            []string                        `json:"subnets,omitempty"`
-	InstanceTypes      []string                        `json:"instanceTypes,omitempty"`
-	UpdateConfig       *EKSNodeGroupUpdateConfig       `json:"updateConfig,omitempty"`
-	ScalingConfig      *EKSNodeGroupScalingConfig      `json:"scalingConfig,omitempty"`
-	LaunchTemplate     *EC2LaunchTemplate              `json:"launchTemplate,omitempty"`
-	RemoteAccessConfig *EKSNodeGroupRemoteAccessConfig `json:"remoteAccessConfig,omitempty"`
-	Resources          *EKSNodeGroupResources          `json:"resources,omitempty"`
-	HealthIssues       []*EKSNodeGroupHealthIssue      `json:"healthIssues,omitempty"`
-	Taints             []*EKSNodeGroupTaint            `json:"taints,omitempty"`
-	Labels             map[string]string               `json:"labels,omitempty"`
-	Tags               map[string]string               `json:"tags,omitempty"`
+	Name                string                          `json:"name,omitempty"`
+	NodegroupArn        *string                         `json:"nodeGroupArn,omitempty"`
+	NodeRole            *string                         `json:"nodeRole,omitempty"`
+	CreatedAt           string                          `json:"createdAt,omitempty"`
+	Status              string                          `json:"status,omitempty"`
+	DiskSize            *int32                          `json:"diskSize,omitempty"`
+	AMIType             string                          `json:"amiType,omitempty"`
+	CapacityType        string                          `json:"capacityType,omitempty"`
+	AMIReleaseVersion   *string                         `json:"amiReleaseVersion,omitempty"`
+	Subnets             []string                        `json:"subnets,omitempty"`
+	AmazonMachineImages []AmazonMachineImage            `json:"amazonMachineImages,omitempty"`
+	UpdateConfig        *EKSNodeGroupUpdateConfig       `json:"updateConfig,omitempty"`
+	ScalingConfig       *EKSNodeGroupScalingConfig      `json:"scalingConfig,omitempty"`
+	LaunchTemplate      *EC2LaunchTemplate              `json:"launchTemplate,omitempty"`
+	RemoteAccessConfig  *EKSNodeGroupRemoteAccessConfig `json:"remoteAccessConfig,omitempty"`
+	Resources           *EKSNodeGroupResources          `json:"resources,omitempty"`
+	HealthIssues        []*EKSNodeGroupHealthIssue      `json:"healthIssues,omitempty"`
+	Taints              []*EKSNodeGroupTaint            `json:"taints,omitempty"`
+	Labels              map[string]string               `json:"labels,omitempty"`
+	Tags                map[string]string               `json:"tags,omitempty"`
 }
 
 // EKSNodeGroupUpdateConfig contains number/percentage of node groups that can be updated in parallel
@@ -115,14 +115,14 @@ type Reservation struct {
 }
 
 type Instance struct {
-	HttpPutResponseHopLimit *int32              `json:"httpPutResponseHopLimit,omitempty"`
-	PublicDnsName           *string             `json:"publicDnsName,omitempty"`
-	AmazonMachineImage      *AmazonMachineImage `json:"amazonMachineImage,omitempty"`
+	HttpPutResponseHopLimit *int32  `json:"httpPutResponseHopLimit,omitempty"`
+	PublicDnsName           *string `json:"publicDnsName,omitempty"`
 }
 
 type AmazonMachineImage struct {
 	Id              *string `json:"id,omitempty"`
 	Name            *string `json:"name,omitempty"`
+	InstanceType    string  `json:"instanceType,omitempty"`
 	Location        *string `json:"location,omitempty"`
 	Type            string  `json:"type,omitempty"`
 	Architecture    string  `json:"architecture,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -574,13 +574,7 @@ func (in *EKSNodeGroup) DeepCopyInto(out *EKSNodeGroup) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.AmazonMachineImages != nil {
-		in, out := &in.AmazonMachineImages, &out.AmazonMachineImages
-		*out = make([]AmazonMachineImage, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
+	in.AmazonMachineImage.DeepCopyInto(&out.AmazonMachineImage)
 	if in.UpdateConfig != nil {
 		in, out := &in.UpdateConfig, &out.UpdateConfig
 		*out = new(EKSNodeGroupUpdateConfig)

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -574,10 +574,12 @@ func (in *EKSNodeGroup) DeepCopyInto(out *EKSNodeGroup) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.InstanceTypes != nil {
-		in, out := &in.InstanceTypes, &out.InstanceTypes
-		*out = make([]string, len(*in))
-		copy(*out, *in)
+	if in.AmazonMachineImages != nil {
+		in, out := &in.AmazonMachineImages, &out.AmazonMachineImages
+		*out = make([]AmazonMachineImage, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	if in.UpdateConfig != nil {
 		in, out := &in.UpdateConfig, &out.UpdateConfig
@@ -864,11 +866,6 @@ func (in *Instance) DeepCopyInto(out *Instance) {
 		in, out := &in.PublicDnsName, &out.PublicDnsName
 		*out = new(string)
 		**out = **in
-	}
-	if in.AmazonMachineImage != nil {
-		in, out := &in.AmazonMachineImage, &out.AmazonMachineImage
-		*out = new(AmazonMachineImage)
-		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/charts/kyverno-aws-adapter/crds/security.nirmata.io_awsadapterconfigs.yaml
+++ b/charts/kyverno-aws-adapter/crds/security.nirmata.io_awsadapterconfigs.yaml
@@ -113,35 +113,33 @@ spec:
                           description: EKSNodeGroup contains info of the EKS cluster's
                             node group
                           properties:
-                            amazonMachineImages:
-                              items:
-                                properties:
-                                  architecture:
-                                    type: string
-                                  creationTime:
-                                    type: string
-                                  deprecationTime:
-                                    type: string
-                                  id:
-                                    type: string
-                                  instanceType:
-                                    type: string
-                                  location:
-                                    type: string
-                                  name:
-                                    type: string
-                                  ownerId:
-                                    type: string
-                                  platformDetails:
-                                    type: string
-                                  public:
-                                    type: boolean
-                                  state:
-                                    type: string
-                                  type:
-                                    type: string
-                                type: object
-                              type: array
+                            amazonMachineImage:
+                              properties:
+                                architecture:
+                                  type: string
+                                creationTime:
+                                  type: string
+                                deprecationTime:
+                                  type: string
+                                id:
+                                  type: string
+                                instanceType:
+                                  type: string
+                                location:
+                                  type: string
+                                name:
+                                  type: string
+                                ownerId:
+                                  type: string
+                                platformDetails:
+                                  type: string
+                                public:
+                                  type: boolean
+                                state:
+                                  type: string
+                                type:
+                                  type: string
+                              type: object
                             amiReleaseVersion:
                               type: string
                             amiType:

--- a/charts/kyverno-aws-adapter/crds/security.nirmata.io_awsadapterconfigs.yaml
+++ b/charts/kyverno-aws-adapter/crds/security.nirmata.io_awsadapterconfigs.yaml
@@ -113,6 +113,35 @@ spec:
                           description: EKSNodeGroup contains info of the EKS cluster's
                             node group
                           properties:
+                            amazonMachineImages:
+                              items:
+                                properties:
+                                  architecture:
+                                    type: string
+                                  creationTime:
+                                    type: string
+                                  deprecationTime:
+                                    type: string
+                                  id:
+                                    type: string
+                                  instanceType:
+                                    type: string
+                                  location:
+                                    type: string
+                                  name:
+                                    type: string
+                                  ownerId:
+                                    type: string
+                                  platformDetails:
+                                    type: string
+                                  public:
+                                    type: boolean
+                                  state:
+                                    type: string
+                                  type:
+                                    type: string
+                                type: object
+                              type: array
                             amiReleaseVersion:
                               type: string
                             amiType:
@@ -138,10 +167,6 @@ spec:
                                       type: string
                                     type: array
                                 type: object
-                              type: array
-                            instanceTypes:
-                              items:
-                                type: string
                               type: array
                             labels:
                               additionalProperties:
@@ -248,31 +273,6 @@ spec:
                                     type: integer
                                   publicDnsName:
                                     type: string
-                                  amazonMachineImage:
-                                    properties:
-                                      id:
-                                        type: string
-                                      name:
-                                        type: string
-                                      location:
-                                        type: string
-                                      type:
-                                        type: string
-                                      architecture:
-                                        type: string
-                                      public:
-                                        type: boolean
-                                      platformDetails:
-                                        type: string
-                                      ownerId:
-                                        type: string
-                                      creationTime:
-                                        type: string
-                                      deprecationTime:
-                                        type: string
-                                      state:
-                                        type: string
-                                    type: object
                                 type: object
                               type: array
                           type: object

--- a/config/crd/bases/security.nirmata.io_awsadapterconfigs.yaml
+++ b/config/crd/bases/security.nirmata.io_awsadapterconfigs.yaml
@@ -113,35 +113,33 @@ spec:
                           description: EKSNodeGroup contains info of the EKS cluster's
                             node group
                           properties:
-                            amazonMachineImages:
-                              items:
-                                properties:
-                                  architecture:
-                                    type: string
-                                  creationTime:
-                                    type: string
-                                  deprecationTime:
-                                    type: string
-                                  id:
-                                    type: string
-                                  instanceType:
-                                    type: string
-                                  location:
-                                    type: string
-                                  name:
-                                    type: string
-                                  ownerId:
-                                    type: string
-                                  platformDetails:
-                                    type: string
-                                  public:
-                                    type: boolean
-                                  state:
-                                    type: string
-                                  type:
-                                    type: string
-                                type: object
-                              type: array
+                            amazonMachineImage:
+                              properties:
+                                architecture:
+                                  type: string
+                                creationTime:
+                                  type: string
+                                deprecationTime:
+                                  type: string
+                                id:
+                                  type: string
+                                instanceType:
+                                  type: string
+                                location:
+                                  type: string
+                                name:
+                                  type: string
+                                ownerId:
+                                  type: string
+                                platformDetails:
+                                  type: string
+                                public:
+                                  type: boolean
+                                state:
+                                  type: string
+                                type:
+                                  type: string
+                              type: object
                             amiReleaseVersion:
                               type: string
                             amiType:

--- a/config/crd/bases/security.nirmata.io_awsadapterconfigs.yaml
+++ b/config/crd/bases/security.nirmata.io_awsadapterconfigs.yaml
@@ -113,6 +113,35 @@ spec:
                           description: EKSNodeGroup contains info of the EKS cluster's
                             node group
                           properties:
+                            amazonMachineImages:
+                              items:
+                                properties:
+                                  architecture:
+                                    type: string
+                                  creationTime:
+                                    type: string
+                                  deprecationTime:
+                                    type: string
+                                  id:
+                                    type: string
+                                  instanceType:
+                                    type: string
+                                  location:
+                                    type: string
+                                  name:
+                                    type: string
+                                  ownerId:
+                                    type: string
+                                  platformDetails:
+                                    type: string
+                                  public:
+                                    type: boolean
+                                  state:
+                                    type: string
+                                  type:
+                                    type: string
+                                type: object
+                              type: array
                             amiReleaseVersion:
                               type: string
                             amiType:
@@ -138,10 +167,6 @@ spec:
                                       type: string
                                     type: array
                                 type: object
-                              type: array
-                            instanceTypes:
-                              items:
-                                type: string
                               type: array
                             labels:
                               additionalProperties:
@@ -243,31 +268,6 @@ spec:
                             instances:
                               items:
                                 properties:
-                                  amazonMachineImage:
-                                    properties:
-                                      architecture:
-                                        type: string
-                                      creationTime:
-                                        type: string
-                                      deprecationTime:
-                                        type: string
-                                      id:
-                                        type: string
-                                      location:
-                                        type: string
-                                      name:
-                                        type: string
-                                      ownerId:
-                                        type: string
-                                      platformDetails:
-                                        type: string
-                                      public:
-                                        type: boolean
-                                      state:
-                                        type: string
-                                      type:
-                                        type: string
-                                    type: object
                                   httpPutResponseHopLimit:
                                     format: int32
                                     type: integer


### PR DESCRIPTION
- Move `AmazonMachineImages` from `Instances` to `Nodegroups`.
- Move `InstanceTypes` from `NodeGroups` to `AmazonMachineImages`.
- Prevent overwriting of `Reservations` and `Nodegroups`.